### PR TITLE
Adds tab parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ Please note that if running on Pyodide the computations will always take place o
 #### Other
 
 - `config` (dict): Optional additional configuration for Graphic Walker. See the [Graphic Walker API](https://github.com/Kanaries/graphic-walker#api) for more details.
+- `tab` (str): Tab shown. One of 'data' or 'vis'.
 
 ### Methods
 

--- a/examples/app_demo.py
+++ b/examples/app_demo.py
@@ -39,8 +39,10 @@ button_style = dict(button_type="primary", button_style="outline")
 walker = GraphicWalker(get_data(), sizing_mode="stretch_both", server_computation=True)
 core_settings = pn.Column(
     walker.param.server_computation,
-    walker.param.config, name="Core"
-
+    walker.param.config,
+    _label("Tab"),
+    pn.widgets.RadioButtonGroup.from_param(walker.param.tab, **button_style),
+    name="Core",
 )
 style_settings = pn.Column(
     _label("Appearance"),

--- a/src/panel_gwalker/_gwalker.py
+++ b/src/panel_gwalker/_gwalker.py
@@ -77,6 +77,7 @@ class GraphicWalker(ReactComponent):
         objects=["vega", "g2", "streamlit"],
         doc="""The theme of the chart(s). One of 'vega' (default), 'g2' or 'streamlit'.""",
     )
+    tab: Literal["data", "vis"] = param.Selector(default="vis", objects=["data", "vis"], doc="""Tab shown. One of 'data' or 'vis'.""")
 
     _importmap = {
         "imports": {

--- a/tests/test_graphic_walker.py
+++ b/tests/test_graphic_walker.py
@@ -32,6 +32,7 @@ def test_constructor(data, default_appearance):
     assert gwalker.object is data
     assert not gwalker.fields
     assert not gwalker.config
+    assert gwalker.tab
     assert gwalker.appearance == default_appearance
 
 


### PR DESCRIPTION
For my use case I would like to be able to set the default tab to 'data' as you can do in Pygwalker.

Ideally the `tab` python parameter should be synced with the javascript value.

![image](https://github.com/user-attachments/assets/30f6159b-fd4c-4cda-891c-1180b3f54fbe)
