### PR TITLE
Implement GraphicWalker.add_chart and support vega-lite export

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,13 +164,14 @@ To learn more about all the parameters and methods of `GraphicWalker`, try the `
 
 #### Export and Save Methods
 
-- `export_chart`: Returns chart(s) from the frontend exported as either Vega specifications or SVG strings.
-- `save_chart`: Saves chart(s) from the frontend exported as either Vega specifications or SVG strings.
+- `export_chart`: Returns chart(s) from the frontend exported as either Graphic Walker Chart specification, vega-lite specification or SVG strings.
+- `save_chart`: Saves chart(s) from the frontend exported as either Graphic Walker Chart specifications, vega-lite specification or SVG strings.
 - `export_controls`: Returns a UI component to export the charts(s) and interactively set `scope`, `mode`, and `timeout` parameters. The `value` parameter will hold the exported spec.
 - `save_controls`: Returns a UI component to export and save the chart(s) acting much like `export_controls`.
 
 #### Other Methods
 
+- `add_chart`: Adds a Chart to the explorer from a Graphic Walker Chart specification.
 - `calculated_field_specs`: Returns a list of *fields* calculated from the `object`. This is a great starting point if you want to provide custom `field_specs`.
 
 ## Vision

--- a/src/panel_gwalker/_gwalker.js
+++ b/src/panel_gwalker/_gwalker.js
@@ -87,7 +87,7 @@ export function render({ model }) {
       }
       let value, exported
       if (e.scope === 'current') {
-	if (e.mode === 'vega') {
+	if (e.mode === 'vega-lite') {
           exported = exporter.lastSpec
 	} else if (e.mode === 'spec') {
           exported = exporter.currentVis

--- a/src/panel_gwalker/_gwalker.py
+++ b/src/panel_gwalker/_gwalker.py
@@ -133,7 +133,9 @@ class ExportControls(Viewer):
 
     @param.depends("mode", watch=True)
     def _update_vega_scope(self):
-        self.param.scope.objects = ["current"] if self.mode == "vega-lite" else ["all", "current"]
+        self.param.scope.objects = (
+            ["current"] if self.mode == "vega-lite" else ["all", "current"]
+        )
 
     @param.depends("run", watch=True)
     async def _export(self):
@@ -446,7 +448,9 @@ class GraphicWalker(ReactComponent):
         Dictionary containing the exported chart(s).
         """
         if mode == "vega-lite" and scope == "all":
-            raise ValueError("Exporting vega-lite specification is only supported for the current chart.")
+            raise ValueError(
+                "Exporting vega-lite specification is only supported for the current chart."
+            )
         event_id = uuid.uuid4().hex
         self._send_msg(
             {"action": "export", "id": event_id, "scope": scope, "mode": mode}
@@ -474,7 +478,7 @@ class GraphicWalker(ReactComponent):
         Arguments
         ---------
         path: str | PathLike | IO
-        mode: 'code' | 'svg' | 
+        mode: 'code' | 'svg' | 'vega-lite'
            Whether to export and save the chart specification(s) or SVG.
         scope: 'current' | 'all'
            Whether to export and save only the current chart or all charts.


### PR DESCRIPTION
A few improvements and fixes:

- Ensure the custom message listener is only added once
- Allow export (current) chart to vega-lite spec
- Stop interval listener after ref is defined
- Add `GraphicWalker.add_chart` method to create chart from spec.