### PR TITLE
Wrap in apostrophes

### DIFF
--- a/src/panel_gwalker/_pygwalker.py
+++ b/src/panel_gwalker/_pygwalker.py
@@ -111,7 +111,7 @@ def get_data_parser(
         )
     except ImportError as exc:
         raise ImportError(
-            "Server dependencies are not installed. Please: pip install panel-graphic-walker[kernel]."
+            "Server dependencies are not installed. Please: pip install 'panel-graphic-walker[kernel]'"
         ) from exc
 
     object_type = type(object)


### PR DESCRIPTION
Without it:
```
pip install panel-graphic-walker[kernel]
zsh: no matches found: panel-graphic-walker[kernel]
```