### PR TITLE
Allows table to fill available space

### DIFF
--- a/src/panel_gwalker/_gwalker.js
+++ b/src/panel_gwalker/_gwalker.js
@@ -37,7 +37,7 @@ function transformSpec(spec) {
   return spec;
 }
 
-export function render({ model }) {
+export function render({ model, el, view }) {
   // Model state
   const [appearance] = model.useState('appearance')
   const [themeKey] = model.useState('theme_key')
@@ -105,6 +105,13 @@ export function render({ model }) {
       model.send_msg({action: 'export', data: value, id: e.id})
     })
   }, [])
+
+  useEffect(() => {
+    if (renderer === 'profiler') {
+      const table = view.container.children[0].shadowRoot.querySelector('div.overflow-y-auto.h-full')
+      table.style.maxHeight = '100%'
+    }
+  }, [storeRef, renderer])
 
   // Data Transforms
   useEffect(() => {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,6 @@ def persistent_conn(tmp_path):
         "pandas",
         "polars",
         "dask",
-        "ibis-duckdb-persistent",
         "ibis-sqlite",
         "duckdb-simple",
         "duckdb-in-memory",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,6 @@ def persistent_conn(tmp_path):
         "pandas",
         "polars",
         "dask",
-        "ibis-sqlite",
         "duckdb-simple",
         "duckdb-in-memory",
         "duckdb-persistent",


### PR DESCRIPTION
Allows the profiler renderer to fill available space rather than enforcing the arbitrary 600px max-height.